### PR TITLE
Add Go Client CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: Go Client CI
+on: 
+  push:
+    branches: main
+  pull_request: { }
+  workflow_dispatch: { }
+jobs:
+  go-client:
+    name: Go client tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache: true
+      - name: Build Go
+        shell: bash
+        id: build-go
+        working-directory: cmd/zbctl
+        run: ./build.sh
+      - name: Run Go tests
+        working-directory: .
+        run: go test -mod=vendor -v ./...
+  go-lint:
+    name: Go linting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache: true
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v4
+        with:
+          # fixed to avoid triggering false positive; see https://github.com/golangci/golangci-lint-action/issues/535
+          version: v1.55.2
+          # caching issues, see: https://github.com/golangci/golangci-lint-action/issues/244#issuecomment-1052190775
+          skip-pkg-cache: true
+          skip-build-cache: true
+          working-directory: .
+  go-apidiff:
+    if: github.event_name == 'pull_request'
+    name: Go Backwards Compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache: true
+      - uses: joelanford/go-apidiff@main

--- a/README.md
+++ b/README.md
@@ -1,47 +1,22 @@
 # Zeebe Go Client
 
-> [!WARNING]
-> The Zeebe Go Client will be officially deprecated with 8.6 release as part of our efforts to streamline the Camunda 8 API experience. This client will not get released with Camunda 8.6, thus no longer receive new features and will be transitioned to a community-maintained status.
-
-### Why This Change?
-
-The decision to deprecate the Go Client aligns with our broader API strategy and resource allocation priorities. The Go Client has seen limited adoption. Moving forward, we are focusing our efforts on the Camunda 8 REST API, which offers a unified, more widely-supported approach for interacting with Zeebe and other Camunda services.
-
-### What Does This Mean for Users?
-
-* No New Features or Updates: Starting with Camunda 8.6, the Go Client will no longer receive new features, updates, or official support from Camunda.
-* The official Go client and zbctl will only remain available and maintained for supported minor versions up to Camunda 8.5.
-* Community Maintenance: The Go Client will be moved to [Camunda Community Hub](https://github.com/camunda-community-hub) and can be maintained by the community. We encourage contributions from users who wish to continue using and improving this client.
-* Transition to REST API: We recommend users transition to the Camunda 8 REST API for all future development. The REST API provides comprehensive functionality and is supported by tools such as cURL, Postman, and OpenAPI.
-
-### Future Considerations
-
-We value feedback from our community. Based on user input, we may explore developing a new client for the Camunda 8 REST API, based on a different technology that aligns with our strategic goals and internal expertise.
-For more information on the deprecation and our API strategy, please refer to the official [Camunda blog](https://camunda.com/blog/).
+The Zeebe Go client is a Go wrapper implementation around the GRPC (https://github.com/grpc/grpc) generated Zeebe client. It makes it possible to communicate with Zeebe Broker via the GRPC protocol, see the [Zeebe documentation](https://docs.zeebe.io/) for more information about the Zeebe project.
 
 # Development
 
 If we had a gateway-protocol change we need to make sure that we regenerate the protobuf file, which is used by the go client.
-In order to do this please follow [this guide](../../gateway-protocol-impl/README.md).
 
 ## Testing
 
 ### gRPC Mock
 
-To regenerate the gateway mock `internal/mock_pb/mock_gateway.go` run [`mockgen`](https://github.com/golang/mock#installation) from the root of this module (`clients/go`):
+To regenerate the gateway mock `internal/mock_pb/mock_gateway.go` run [`mockgen`](https://github.com/golang/mock#installation) from the root of this project:
 
 ```
 mockgen -source=pkg/pb/gateway.pb.go GatewayClient,Gateway_ActivateJobsClient > internal/mock_pb/mock_gateway.go
 ```
 
 ### Integration tests
-
-To run the integration tests, a Docker image for Zeebe must be built with the tag 'current-test'.
-To do that you can run the following command from the root of this repository:
-
-```
-docker build --build-arg DIST=build -t camunda/zeebe:current-test .
-```
 
 To add new zbctl tests, you must generate a golden file with the expected output of the command you are testing. The tests ignore numbers so you can leave any keys or timestamps in your golden file, even though these will most likely be different from test command's output. However, non-numeric variables are not ignored. For instance, the help menu contains:
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ mockgen -source=pkg/pb/gateway.pb.go GatewayClient,Gateway_ActivateJobsClient > 
 
 ### Integration tests
 
+Integration tests run zeebe in a container to test the client against. The version of Zeebe used is managed via 
+a constant in [`internal/containersuite/containerSuite.go`](internal/containersuite/containerSuite.go#L36).
+
 To add new zbctl tests, you must generate a golden file with the expected output of the command you are testing. The tests ignore numbers so you can leave any keys or timestamps in your golden file, even though these will most likely be different from test command's output. However, non-numeric variables are not ignored. For instance, the help menu contains:
 
 ```

--- a/cmd/zbctl/main_test.go
+++ b/cmd/zbctl/main_test.go
@@ -251,8 +251,7 @@ func TestZbctlWithInsecureGateway(t *testing.T) {
 	suite.Run(t,
 		&integrationTestSuite{
 			ContainerSuite: &containersuite.ContainerSuite{
-				WaitTime:       time.Second,
-				ContainerImage: "camunda/zeebe:8.6.0-alpha5",
+				WaitTime: time.Second,
 				Env: map[string]string{
 					"ZEEBE_BROKER_GATEWAY_LONGPOLLING_ENABLED": "false",
 				},

--- a/cmd/zbctl/main_test.go
+++ b/cmd/zbctl/main_test.go
@@ -252,7 +252,7 @@ func TestZbctlWithInsecureGateway(t *testing.T) {
 		&integrationTestSuite{
 			ContainerSuite: &containersuite.ContainerSuite{
 				WaitTime:       time.Second,
-				ContainerImage: "camunda/zeebe:current-test",
+				ContainerImage: "camunda/zeebe:8.6.0-alpha5",
 				Env: map[string]string{
 					"ZEEBE_BROKER_GATEWAY_LONGPOLLING_ENABLED": "false",
 				},

--- a/internal/containersuite/containerSuite.go
+++ b/internal/containersuite/containerSuite.go
@@ -33,6 +33,8 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+const dockerImageName = "camunda/zeebe:8.6.0-alpha5"
+
 type zeebeWaitStrategy struct {
 	waitTime time.Duration
 }
@@ -152,8 +154,6 @@ func isStable(res *pb.TopologyResponse) bool {
 type ContainerSuite struct {
 	// WaitTime specifies the wait period before checking if the container is up
 	WaitTime time.Duration
-	// ContainerImage is the ID of docker image to be used
-	ContainerImage string
 	// GatewayAddress is the contact point of the spawned Zeebe container specified in the format 'host:port'
 	GatewayAddress string
 	GatewayHost    string
@@ -198,14 +198,13 @@ func (s *ContainerSuite) SetupSuite() {
 	var err error
 	req := testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        s.ContainerImage,
+			Image:        dockerImageName,
 			ExposedPorts: []string{"26500/tcp", "9600/tcp"},
 			WaitingFor:   zeebeWaitStrategy{waitTime: s.WaitTime},
 			Env: map[string]string{
 				"ZEEBE_BROKER_NETWORK_HOST":           "0.0.0.0",
 				"ZEEBE_BROKER_NETWORK_ADVERTISEDHOST": "0.0.0.0",
 			},
-			AlwaysPullImage: true,
 		},
 		Started: true,
 	}

--- a/internal/containersuite/containerSuite.go
+++ b/internal/containersuite/containerSuite.go
@@ -25,7 +25,6 @@ import (
 	"github.com/camunda/camunda/clients/go/v8/internal/utils"
 	"github.com/camunda/camunda/clients/go/v8/pkg/pb"
 	"github.com/camunda/camunda/clients/go/v8/pkg/zbc"
-	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
 	"github.com/stretchr/testify/suite"
 	"github.com/testcontainers/testcontainers-go"
@@ -206,6 +205,7 @@ func (s *ContainerSuite) SetupSuite() {
 				"ZEEBE_BROKER_NETWORK_HOST":           "0.0.0.0",
 				"ZEEBE_BROKER_NETWORK_ADVERTISEDHOST": "0.0.0.0",
 			},
+			AlwaysPullImage: true,
 		},
 		Started: true,
 	}
@@ -216,10 +216,6 @@ func (s *ContainerSuite) SetupSuite() {
 	}
 
 	ctx := context.Background()
-	err = validateImageExists(ctx, s.ContainerImage)
-	if err != nil {
-		s.T().Fatal(err)
-	}
 
 	s.container, err = testcontainers.GenericContainer(ctx, req)
 	if err != nil {
@@ -257,21 +253,4 @@ func (s *ContainerSuite) TearDownSuite() {
 	if err != nil {
 		s.T().Fatal(err)
 	}
-}
-
-func validateImageExists(ctx context.Context, image string) error {
-	dockerClient, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
-	if err != nil {
-		return fmt.Errorf("failed creating docker client: %w", err)
-	}
-
-	_, _, err = dockerClient.ImageInspectWithRaw(ctx, image)
-	if err != nil {
-		if client.IsErrNotFound(err) {
-			return fmt.Errorf("a Docker image containing Zeebe must be built and named '%s'", image)
-		}
-
-		return err
-	}
-	return nil
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-const dockerImageName = "camunda/zeebe:current-test"
+const dockerImageName = "camunda/zeebe:8.6.0-alpha5"
 
 type integrationTestSuite struct {
 	*containersuite.ContainerSuite

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -32,8 +32,6 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-const dockerImageName = "camunda/zeebe:8.6.0-alpha5"
-
 type integrationTestSuite struct {
 	*containersuite.ContainerSuite
 	client zbc.Client
@@ -42,8 +40,7 @@ type integrationTestSuite struct {
 func TestIntegration(t *testing.T) {
 	suite.Run(t, &integrationTestSuite{
 		ContainerSuite: &containersuite.ContainerSuite{
-			WaitTime:       time.Second,
-			ContainerImage: dockerImageName,
+			WaitTime: time.Second,
 		},
 	})
 }
@@ -451,8 +448,7 @@ func TestSlowWorker(t *testing.T) {
 	suite.Run(t, &slowWorkerSuite{
 		integrationTestSuite: &integrationTestSuite{
 			ContainerSuite: &containersuite.ContainerSuite{
-				WaitTime:       time.Second,
-				ContainerImage: dockerImageName,
+				WaitTime: time.Second,
 				Env: map[string]string{
 					"ZEEBE_DEBUG":     "true",
 					"ZEEBE_LOG_LEVEL": "debug",


### PR DESCRIPTION
Adds CI to run on main and PRs.

The following stages are equivalent to their base from [camunda/camunda](https://github.com/camunda/camunda/blob/main/.github/workflows/zeebe-ci.yml#L195-L253): `go-client` (run tests) and `go-lint`.

The `go-apidiff` job was previously [comparing the Go client state to the latest stable branch](https://github.com/camunda/camunda/blob/main/.github/workflows/zeebe-ci.yml#L254-L284), I went for protecting from breaking changes on each PR instead. As there are not existing releases on this new repo.

Instead of using as freshly built Zeebe image for the integration tests I went for referencing the latest 8.6.0-alpha5 release, also instructing test containers to automatically pull it.

Note: I'm making progress on this repo until we have the community hub repo created see https://github.com/camunda-community-hub/community/issues/159